### PR TITLE
Corrected string delimiters.

### DIFF
--- a/GDScript.plist
+++ b/GDScript.plist
@@ -167,9 +167,9 @@
 		<string>#</string>
     <!-- Strings -->
 		<key>Open Strings 1</key>
-		<string>'</string>
+		<string>"</string>
 		<key>Close Strings 1</key>
-		<string>'</string>
+		<string>"</string>
 		<key>Escape Char in Strings 1</key>
 		<string>\</string>
 		<key>End-of-line Ends Strings 1</key>


### PR DESCRIPTION
Had accidentally set the string delimiter character as a single-quote `'` instead of the correct double-quote `"`.

Fixes issue #2.