### PR TITLE
Fix Issue #4 — support single-quote string delimiters

### DIFF
--- a/GDScript.plist
+++ b/GDScript.plist
@@ -167,12 +167,20 @@
 		<string>#</string>
     <!-- Strings -->
 		<key>Open Strings 1</key>
-		<string>"</string>
+		<string>'</string>
 		<key>Close Strings 1</key>
-		<string>"</string>
+		<string>'</string>
 		<key>Escape Char in Strings 1</key>
 		<string>\</string>
 		<key>End-of-line Ends Strings 1</key>
+		<false/>
+		<key>Open Strings 2</key>
+		<string>"</string>
+		<key>Close Strings 2</key>
+		<string>"</string>
+		<key>Escape Char in Strings 2</key>
+		<string>\</string>
+		<key>End-of-line Ends Strings 2</key>
 		<false/>
     <!-- Functions -->
 		<key>Prefix for Functions</key>


### PR DESCRIPTION
No sooner had I made the previous “fix” (or, what I thought was a fix) than I learned that GDScript _does_ support single-quote delimiters for strings, in addition to the more common double-quote delimiters.

So, this commit adds the keys for single-quote delimiters to work, too.

Fixes issue #4.